### PR TITLE
Fix pyproject.toml typo that prevented installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "MIMO in Pytorch"
+name = "MIMO_pytorch"
 version = "0.0.1"
 description = "MIMO - Controllable Character Video Synthesis"
 authors = [


### PR DESCRIPTION
Removed spaces from project.name:  'MIMO in Pytorch' to 'MIMO_pytorch'